### PR TITLE
Add wolframalpha helper to linkcache

### DIFF
--- a/linkcache/config.ini.dist
+++ b/linkcache/config.ini.dist
@@ -30,6 +30,9 @@ password: password
 cookiejar: /path/to/cookies.txt
 passwords: /path/to/passwords.csv
 
+[wolframalpha]
+appid: appid
+
 [google]
 regex: ^(\w*\s*\|\s*|)@google (.*)
 rewriter: from urllib import urlencode

--- a/linkcache/helpers/wolframalphahelper.py
+++ b/linkcache/helpers/wolframalphahelper.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-,
+
+from common import UrlHelper
+import wolframalpha
+import json
+import re
+
+class WolframAlphaHelper(UrlHelper):
+    config_section = 'wolframalpha'
+    def __init__(self, config):
+        UrlHelper.__init__(self, config)
+        self.url_regex = re.compile('^(\w*\s*\|\s*|)@calc (.*)')
+        self.appid = config['appid']
+
+    def fetch(self, browser, url):
+        expression = url
+        json_result = {}
+        json_result['expression'] = expression
+        json_result['result'] = ""
+        client = wolframalpha.Client(self.appid)
+        res = client.query(url)
+        first_result = next(res.results, "")
+        if first_result != "":
+            json_result['result'] = first_result.text
+        return json.dumps(json_result)
+
+instantiate = WolframAlphaHelper
+# vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/linkcache/tests/test_all.py
+++ b/linkcache/tests/test_all.py
@@ -16,6 +16,7 @@ testmodules = [
 	"linkcache.tests.test_twitter",
 	"linkcache.tests.test_youtube",
 	"linkcache.tests.test_soundcloud",
+	"linkcache.tests.test_wolframalpha",
     ]
 
 suite = unittest.TestSuite()

--- a/linkcache/tests/test_wolframalpha.py
+++ b/linkcache/tests/test_wolframalpha.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-,
+import unittest
+import ConfigParser
+import json
+from urllib import urlencode
+
+from linkcache import browser
+from linkcache.helpers import wolframalphahelper
+
+class WolframAlphaTests(unittest.TestCase):
+
+    def setUp(self):
+        config = ConfigParser.ConfigParser()
+        config.read('../../config.ini')
+        conf = dict(config.items(wolframalphahelper.instantiate.config_section))
+        self.browser = browser.SingletonBrowser()
+        self.helper = wolframalphahelper.instantiate(conf)
+
+    def test_wolframalpha_simple_expression(self):
+        expression = "5 + 5"
+        ret = json.loads(self.helper.fetch(self.browser, expression))
+        self.assertTrue(ret['expression'] == "5 + 5" and ret['result'] == "10")
+
+    def test_wolframalpha_complex_expression(self):
+        expression = "temperature in Washington, DC on October 3, 2012"
+        ret = json.loads(self.helper.fetch(self.browser, expression))
+        self.assertTrue(ret['result'] == u"(70 to 81) \xb0F (average: 75 \xb0F)\n(Wednesday, October 3, 2012)")
+
+    def test_wolframalpha_junk(self):
+        expression = "slksjdflasknenwnqwn;qlkne;qlkjeocina;sdnfasdf"
+        ret = json.loads(self.helper.fetch(self.browser, expression))
+        self.assertTrue(ret['result'] == "")
+
+    def test_matching(self):
+        expression = "please @calc 5 + 5"
+        self.helper.match(expression)
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "python_twitter",
         "mechanize",
         "soundcloud",
+        "wolframalpha",
     ],
 
     author = "Jeff Mahoney",


### PR DESCRIPTION
Add a wolfram!alpha helper to linkcache. Requires a an API ID from WolframAlpha to use.
